### PR TITLE
Ajuste da conversão do dhEmi do recibo

### DIFF
--- a/src/application/helpers/generate-pdf/nfe/get-recibo.ts
+++ b/src/application/helpers/generate-pdf/nfe/get-recibo.ts
@@ -1,5 +1,4 @@
-import { format, parseISO } from 'date-fns';
-import { formatNumber } from '../../../../domain/use-cases/utils';
+import { formatDateTime, formatNumber } from '../../../../domain/use-cases/utils';
 import type { GeneratePdf } from '../../../../types';
 import { linhaHorizontal } from './linha-horizontal';
 import { linhaHorizontalTracejada } from './linha-horizontal-tracejada';
@@ -39,7 +38,7 @@ export function getRecibo({
       'os produtos e/ou serviços constantes da nota',
       'fiscal eletrônica indicada abaixo.',
       'Emissão:',
-      format(parseISO(ide.dhEmi), 'dd/MM/yyyy HH:mm:ss'),
+      formatDateTime(ide.dhEmi),
       '- Valor Total:',
       formatNumber(total.ICMSTot.vNF, 2),
       '- Destinatário:',


### PR DESCRIPTION
Utiliza o método formatDateTime para realizar a conversão.
Dessa forma, a data e hora passam a ser representadas conforme o XML, sem influência do fuso horário da máquina.